### PR TITLE
Add dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,12 @@
 
 <body id="top" class="dark">
   <div id="app" class="container"></div>
+  <script>
+    if (window.matchMedia &&
+        window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.body.classList.add('dark');
+    }
+  </script>
   <script type="module" src="/src/main.js"></script>
 </body>
 

--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@
   <link rel="stylesheet" href="https://unicons.iconscout.com/release/v4.0.0/css/line.css">
 </head>
 
-<body id="top" class="dark">
+<body id="top">
   <div id="app" class="container"></div>
   <script>
     if (window.matchMedia &&
-        window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      window.matchMedia('(prefers-color-scheme: dark)').matches) {
       document.body.classList.add('dark');
     }
   </script>

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,24 +1,24 @@
-body>.container {
+body.dark {
+    --bg-color: #262626;
+    --bg-secondary-color: #131316;
+    --font-color: #f5f5f5;
+    --color-grey: #777;
+    --color-darkGrey: #555;
+    --color-lightGrey: #555;
+}
+
+body > .container {
     max-width: 720px;
-}
-
-body>footer {
-    background-color: #fafafa;
-    padding: 4rem;
-}
-
-body.dark>footer {
-    background-color: #262626;
 }
 
 section {
     margin: 5rem auto;
 }
 
-.install button {
-    text-align: center;
+input, .sortable-list {
+    background-color: var(--bg-secondary-color);
 }
 
-.install {
-    margin-bottom: 1rem;
+::placeholder {
+    color: var(--font-color);
 }

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -19,6 +19,6 @@ input, .sortable-list {
     background-color: var(--bg-secondary-color);
 }
 
-::placeholder {
+input::placeholder, input {
     color: var(--font-color);
 }

--- a/src/components/AddonItem.vue
+++ b/src/components/AddonItem.vue
@@ -96,6 +96,10 @@ function removeAddon() {
   justify-content: space-between;
 }
 
+.dark .sortable-list .item {
+  border: 1px solid #434242;
+}
+
 .item .details {
   display: flex;
   align-items: center;

--- a/src/components/AddonItem.vue
+++ b/src/components/AddonItem.vue
@@ -87,7 +87,6 @@ function removeAddon() {
   list-style: none;
   display: flex;
   cursor: move;
-  background: #fff;
   align-items: center;
   border-radius: 5px;
   padding: 10px 13px;

--- a/src/components/Configuration.vue
+++ b/src/components/Configuration.vue
@@ -134,7 +134,6 @@ function getNestedObjectProperty(obj, path, defaultValue = null) {
 /* sortable list/addon list specifics */
 .sortable-list {
     padding: 25px;
-    background: #fff;
     border-radius: 7px;
     padding: 30px 25px 20px;
     box-shadow: 0 15px 30px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
Enables a dark theme based on the user's system-wide theme settings.

Dark mode enabled:

<img width="515" alt="image" src="https://github.com/pancake3000/stremio-addon-manager/assets/30344294/ca70c136-1eb7-4831-8092-7e87adcf9c4b">

Dark mode disabled:

<img width="515" alt="image" src="https://github.com/pancake3000/stremio-addon-manager/assets/30344294/f6bdf61c-44f8-4fbe-8180-e2937ff7bf9c">

I've also tweaked the colors of the input fields a bit to better match light mode.