### PR TITLE
Add stremio login

### DIFF
--- a/src/components/Authentication.vue
+++ b/src/components/Authentication.vue
@@ -1,0 +1,100 @@
+<script setup>
+import { ref } from 'vue'
+
+const props = defineProps({
+    stremioAPIBase: {
+        type: String,
+        required: true
+    },
+})
+
+const authKey = ref('')
+const email = ref('')
+const password = ref('')
+const loginButtonText = ref('Login')
+const emits = defineEmits(['auth-key'])
+
+async function loginUserPassword() {
+    try {
+        fetch(`${props.stremioAPIBase}login`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                authKey: null,
+                email: email.value,
+                password: password.value,
+            })
+        }).then((resp) => {
+            resp.json().then((data) => {
+                console.log("Auth data:" + data)
+                authKey.value = data.result.authKey
+                loginButtonText.value = 'Logged in'
+                emitAuthKey()
+            })
+        })
+    } catch (err) {
+        console.error(err);
+        alert('Login failed: ' + err.message);
+    }
+}
+
+function emitAuthKey() {
+    emits('auth-key', authKey.value.replaceAll('"', '').trim())
+}
+
+</script>
+
+<template>
+    <legend>Step 0: Authenticate</legend>
+    <p class="grouped">
+        <input type="text" v-model="email" placeholder="Stremio E-mail">
+        <input type="password" v-model="password" placeholder="Stremio Password">
+        <button class="button primary" @click="loginUserPassword">
+            Login
+        </button>
+    </p>
+    <p>
+        <strong>OR</strong>
+    </p>
+    <p class="grouped">
+        <input type="password" v-model="authKey" v-on:input="emitAuthKey" placeholder="Paste Stremio AuthKey here...">
+    </p>
+</template>
+
+<style scoped>
+.sortable-list .item {
+    list-style: none;
+    display: flex;
+    cursor: move;
+    align-items: center;
+    border-radius: 5px;
+    padding: 10px 13px;
+    margin-bottom: 11px;
+    /* box-shadow: 0 2px 4px rgba(0,0,0,0.06); */
+    border: 1px solid #ccc;
+    justify-content: space-between;
+}
+
+.dark .sortable-list .item {
+    border: 1px solid #434242;
+}
+
+.item .details {
+    display: flex;
+    align-items: center;
+}
+
+.item .details img {
+    height: 60px;
+    width: 60px;
+    pointer-events: none;
+    margin-right: 12px;
+    object-fit: contain;
+    object-position: center;
+    border-radius: 30%;
+    background-color: #262626;
+
+}
+</style>

--- a/src/components/Configuration.vue
+++ b/src/components/Configuration.vue
@@ -6,9 +6,13 @@ import AddonItem from './AddonItem.vue'
 const stremioAPIBase = "https://api.strem.io/api/"
 
 const stremioAuthKey = ref('')
+const stremioEmail = ref('')
+const stremioPassword = ref('')
+const dragging = false
+
 let addons = ref([])
 let loadAddonsButtonText = ref('Load Addons')
-const dragging = false
+let loginButtonText = ref('Login')
 
 function getCleansedStremioAuthKey() {
     return stremioAuthKey.value.replaceAll('"', '').trim();
@@ -97,6 +101,31 @@ function getNestedObjectProperty(obj, path, defaultValue = null) {
     }
 }
 
+async function login() {
+    try {
+        fetch(`${stremioAPIBase}login`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                authKey: null,
+                email: stremioEmail.value,
+                password: stremioPassword.value,
+            })
+        }).then((resp) => {
+            resp.json().then((data) => {
+                console.log(data)
+                stremioAuthKey.value = data.result.authKey
+                loginButtonText.value = 'Logged in'
+            })
+        })
+    } catch (err) {
+        console.error(err);
+        alert('Login failed: ' + err.message);
+    }
+}
+
 </script>
 
 <template>
@@ -104,13 +133,23 @@ function getNestedObjectProperty(obj, path, defaultValue = null) {
         <h2>Configure</h2>
         <form onsubmit="return false;">
             <fieldset>
-                <legend>Step 0: Paste Stremio AuthKey</legend>
-                <p class="grouped">
-                    <input type="password" v-model="stremioAuthKey" placeholder="Paste Stremio AuthKey here...">
-                    <button class="button primary" @click="loadUserAddons">
-                        {{ loadAddonsButtonText }}
+                <legend>Step 0: Authenticate</legend>
+                 <p class="grouped">
+                    <input type="text" v-model="stremioEmail" placeholder="Stremio E-mail">
+                    <input type="password" v-model="stremioPassword" placeholder="Stremio Password">
+                    <button class="button primary" @click="login">
+                        {{ loginButtonText }}
                     </button>
                 </p>
+                <p>
+                    <strong>OR</strong>
+                </p>
+                <p class="grouped">
+                    <input type="password" v-model="stremioAuthKey" placeholder="Paste Stremio AuthKey here...">
+                </p>
+                 <button class="button primary" @click="loadUserAddons">
+                        {{ loadAddonsButtonText }}
+                    </button>
             </fieldset>
             <fieldset id="form_step1">
                 <legend>Step 1: Re-Order Addons</legend>

--- a/src/components/FAQ.vue
+++ b/src/components/FAQ.vue
@@ -17,6 +17,17 @@
         </details>
         <details>
             <summary>
+                Are my credentials safe?
+            </summary>
+            <p>
+                Yes. We only use your credentials to authenticate with the Stremio API. We do not store them in any way; as soon as you refresh the page they are gone.
+            </p>
+            <p>
+                If you're still in doubt, we highly encourage you to go read the source code. You'll see there's no hidden funny business going on.
+            </p>
+        </details>
+        <details>
+            <summary>
                 What is the developer console and how do I open it?
             </summary>
             <p>

--- a/src/components/Summary.vue
+++ b/src/components/Summary.vue
@@ -2,29 +2,47 @@
   <section id="features">
     <h2>Why?</h2>
     <p>
-      Stremio currently doesn't allow users to change the order that their installed addons appear on the home
-      screen.
-      As a work around, it is common for users to remove and re-install addons in the order they want
-      them to appear. This is a tedious and cumbersome process. This addon uses the internal Stremio API to
-      manipulate addon order without having to add/remove them.
+      Stremio currently doesn't allow users to change the order that their
+      installed addons appear on the home screen. As a work around, it is common
+      for users to remove and re-install addons in the order they want them to
+      appear. This is a tedious and cumbersome process. This addon uses the
+      internal Stremio API to manipulate addon order without having to
+      add/remove them.
     </p>
     <p>
-      This is a <strong>workaround</strong> and not a <strong>solution</strong>. It is not recommended to
-      use this tool unless you are comfortable with the risks involved.
+      This is a <strong>workaround</strong> and not a <strong>solution</strong>.
+      It is not recommended to use this tool unless you are comfortable with the
+      risks involved.
       <strong>No support or warranty is given.</strong>
     </p>
     <h3>How?</h3>
     <ol>
-      <li>Login to <a href="https://web.stremio.com/" target="_blank">https://web.stremio.com/</a> using your Stremio
-        credentials in your browser.</li>
-      <li>
-        Open the developer console <a href="#faq">(?)</a> and paste the follow code snippet:
-        <code>JSON.parse(localStorage.getItem("profile")).auth.key</code>
-      </li>
-      <li>Take the output value and paste it into the form below.</li>
+      <li>Connect your Stremio account. We support 2 different authentication methods:</li>
+      <ul>
+        <li>Login using your Stremio account (Facebook login is <strong>not supported</strong>)</li>
+        <li>Login using an authentication key</li>
+        <ul>
+          <li>
+            Login to
+            <a href="https://web.stremio.com/" target="_blank"
+              >https://web.stremio.com/</a
+            >
+            using your Stremio credentials in your browser.
+          </li>
+          <li>
+            Open the developer console <a href="#faq">(?)</a> and paste the
+            follow code snippet:
+            <code>JSON.parse(localStorage.getItem("profile")).auth.key</code>
+          </li>
+          <li>Take the output value and paste it into the form below.</li>
+        </ul>
+      </ul>
       <li>Click 'Load Addons' to load your profiles addons.</li>
       <li>Re-order your addons as you like.</li>
-      <li>Click the 'Sync To Stremio' button to sync the changes back to your profile.</li>
+      <li>
+        Click the 'Sync To Stremio' button to sync the changes back to your
+        profile.
+      </li>
     </ol>
   </section>
 </template>


### PR DESCRIPTION
This is an initial POC for login with a Stremio account. When the user clicks log in, a single API request is sent which logs the user in. If successful, the authentication key is read and 'copied over' to the authentication key field so the addon can be used as usual. If there's an error, it's logged to console and an alert is shown to the user.

Perhaps we should turn the 'log in' button into a 'logout' button on successful login. It's not *that* useful considering the auth key isn't stored, but it probably gives peace of mind to users that the option is there. We keep it in local state so it should be possible to just call `/logout` with the `authKey`.